### PR TITLE
Add suport for alias when using ajax_search_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ end
 # Main resource
 # As a filter
 ActiveAdmin.register Invoice do
-  filter :user, as: :ajax_select, data: { 
-    url: :filter_admin_users_path, 
-    search_fields: [:email, :customer_uid], 
+  filter :user, as: :ajax_select, data: {
+    url: :filter_admin_users_path,
+    search_fields: [:email, :customer_uid],
     limit: 7,
   }
   # ...
@@ -72,10 +72,10 @@ end
 ActiveAdmin.register Invoice do
   form do |f|
     f.input :language # used by ajax_search_fields
-    f.input :user, as: :ajax_select, data: { 
+    f.input :user, as: :ajax_select, data: {
       url: filter_admin_users_path,
-      search_fields: [:name], 
-      static_ransack: { active_eq: true }, 
+      search_fields: [:name],
+      static_ransack: { active_eq: true },
       ajax_search_fields: [:language_id],
     }
     # ...
@@ -93,10 +93,11 @@ You can use next parameters in `data` hash:
 * `ransack` - ransack query which will be applied, by default it's builded from `search_fields` with `or` and `contains` clauses, e.g.: `email_or_customer_uid_cont`
 * `url` - url for AJAX query by default is builded from field name. For inputs you can use url helpers, but on filters level url helpers isn't available, so if you need them you can pass symbols and it will be evaluated as url path (e.g. `:filter_admin_users_path`). `String` with relative path (like `/admin/users/filter`) can be used for both inputs and filters.
 * `ajax_search_fields` - array of field names. `ajax_select` input depends on `ajax_search_fields` values: e.g. you can scope user by languages.
+* `ajax_search_alias_fields` - array of field names. Will assign aliases to existing fields in ajax_search_fields. The query will be executed with these fields.
 * `static_ransack` - hash of ransack predicates which will be applied statically and independently from current input field value
 * `min_chars_count_to_request` - minimal count of chars in the input field to make an AJAX request
 
-## Caveats 
+## Caveats
 
 ### Ransack _cont on Integer column
 

--- a/app/assets/javascripts/activeadmin-ajax_filter.js.coffee
+++ b/app/assets/javascripts/activeadmin-ajax_filter.js.coffee
@@ -13,8 +13,12 @@ $ ->
       minCharsCountToRequest = select.data('min-chars-count-to-request') || 1
 
       ajaxFields = select.data('ajax-search-fields')
+      ajaxAliasFields = select.data('ajax-search-alias-fields')
       if ajaxFields
-        ajaxFields = ajaxFields.split(' ')
+        if ajaxAliasFields
+          ajaxFields = ajaxAliasFields.split(' ')
+        else
+          ajaxFields = ajaxFields.split(' ')
       else
         ajaxFields = []
 

--- a/lib/active_admin/ajax_filter/version.rb
+++ b/lib/active_admin/ajax_filter/version.rb
@@ -1,5 +1,5 @@
 module ActiveAdmin
   module AjaxFilter
-    VERSION = '0.4.2'
+    VERSION = '0.5.0'
   end
 end

--- a/lib/active_admin/inputs/ajax_core.rb
+++ b/lib/active_admin/inputs/ajax_core.rb
@@ -14,6 +14,7 @@ module ActiveAdmin
           'data-display-fields' => display_fields,
           'data-search-fields' => search_fields,
           'data-ajax-search-fields' => ajax_search_fields,
+          'data-ajax-search-alias-fields' => ajax_search_alias_fields,
           'data-ordering' => ordering,
           'data-ransack' => ransack,
           'data-static-ransack' => static_ransack,
@@ -49,6 +50,10 @@ module ActiveAdmin
 
       def ajax_search_fields
         ajax_data[:ajax_search_fields]
+      end
+
+      def ajax_search_alias_fields
+        ajax_data[:ajax_search_alias_fields]
       end
 
       def ordering

--- a/spec/active_admin/inputs/ajax_core_spec.rb
+++ b/spec/active_admin/inputs/ajax_core_spec.rb
@@ -96,6 +96,42 @@ RSpec.describe ActiveAdmin::Inputs::AjaxCore do
     end
   end
 
+  describe '#ajax_search_alias_fields' do
+    subject { filter.ajax_search_alias_fields }
+
+    context 'no ajax_search_alias_fields in data' do
+      it 'should be nil' do
+        is_expected.to be_nil
+      end
+    end
+
+    context '#ajax_search_alias_fields in data' do
+      let(:data) { { ajax_search_alias_fields: [:name, :email] } }
+
+      it 'should use explicit value' do
+        is_expected.to eq [:name, :email]
+      end
+    end
+  end
+
+  describe '#ajax_search_fields' do
+    subject { filter.ajax_search_fields }
+
+    context 'no ajax_search_fields in data' do
+      it 'should be nil' do
+        is_expected.to be_nil
+      end
+    end
+
+    context '#ajax_search_fields in data' do
+      let(:data) { { ajax_search_fields: [:name, :email] } }
+
+      it 'should use explicit value' do
+        is_expected.to eq [:name, :email]
+      end
+    end
+  end
+
   describe '#ordering' do
     subject { filter.ordering }
 


### PR DESCRIPTION
These fields provided by the alias will overwrite the fields provided by the ajax_search_fields in the search URL, but the values will be obtained via the fields provided by the ajax_search_fields.